### PR TITLE
Make MemStorage synchronous

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -8,38 +8,38 @@ import {
 
 export interface IStorage {
   // User methods
-  getUser(id: number): Promise<User | undefined>;
-  getUserByUsername(username: string): Promise<User | undefined>;
-  getUserByEmail(email: string): Promise<User | undefined>;
-  createUser(user: InsertUser): Promise<User>;
+  getUser(id: number): User | undefined;
+  getUserByUsername(username: string): User | undefined;
+  getUserByEmail(email: string): User | undefined;
+  createUser(user: InsertUser): User;
   
   // Post methods
-  getPost(id: number): Promise<Post | undefined>;
-  getPostBySlug(slug: string): Promise<Post | undefined>;
-  getPosts(limit?: number, offset?: number): Promise<Post[]>;
-  getPostsByCategory(categoryId: number, limit?: number, offset?: number): Promise<Post[]>;
-  getHotPosts(limit?: number): Promise<Post[]>;
-  createPost(post: InsertPost): Promise<Post>;
-  updatePost(id: number, post: Partial<InsertPost>): Promise<Post>;
-  deletePost(id: number): Promise<boolean>;
-  incrementHeatCount(id: number): Promise<boolean>;
+  getPost(id: number): Post | undefined;
+  getPostBySlug(slug: string): Post | undefined;
+  getPosts(limit?: number, offset?: number): Post[];
+  getPostsByCategory(categoryId: number, limit?: number, offset?: number): Post[];
+  getHotPosts(limit?: number): Post[];
+  createPost(post: InsertPost): Post;
+  updatePost(id: number, post: Partial<InsertPost>): Post;
+  deletePost(id: number): boolean;
+  incrementHeatCount(id: number): boolean;
   
   // Comment methods
-  getComment(id: number): Promise<Comment | undefined>;
-  getCommentsByPost(postId: number): Promise<Comment[]>;
-  createComment(comment: InsertComment): Promise<Comment>;
-  deleteComment(id: number): Promise<boolean>;
+  getComment(id: number): Comment | undefined;
+  getCommentsByPost(postId: number): Comment[];
+  createComment(comment: InsertComment): Comment;
+  deleteComment(id: number): boolean;
   
   // Gallery methods
-  getGalleryItem(id: number): Promise<GalleryItem | undefined>;
-  getGalleryItems(limit?: number, offset?: number): Promise<GalleryItem[]>;
-  createGalleryItem(item: InsertGalleryItem): Promise<GalleryItem>;
+  getGalleryItem(id: number): GalleryItem | undefined;
+  getGalleryItems(limit?: number, offset?: number): GalleryItem[];
+  createGalleryItem(item: InsertGalleryItem): GalleryItem;
   
   // Category methods
-  getCategory(id: number): Promise<Category | undefined>;
-  getCategoryBySlug(slug: string): Promise<Category | undefined>;
-  getCategories(): Promise<Category[]>;
-  createCategory(category: InsertCategory): Promise<Category>;
+  getCategory(id: number): Category | undefined;
+  getCategoryBySlug(slug: string): Category | undefined;
+  getCategories(): Category[];
+  createCategory(category: InsertCategory): Category;
 }
 
 export class MemStorage implements IStorage {
@@ -73,23 +73,23 @@ export class MemStorage implements IStorage {
   }
 
   // User methods
-  async getUser(id: number): Promise<User | undefined> {
+  getUser(id: number): User | undefined {
     return this.users.get(id);
   }
 
-  async getUserByUsername(username: string): Promise<User | undefined> {
+  getUserByUsername(username: string): User | undefined {
     return Array.from(this.users.values()).find(
       (user) => user.username.toLowerCase() === username.toLowerCase()
     );
   }
   
-  async getUserByEmail(email: string): Promise<User | undefined> {
+  getUserByEmail(email: string): User | undefined {
     return Array.from(this.users.values()).find(
       (user) => user.email.toLowerCase() === email.toLowerCase()
     );
   }
 
-  async createUser(insertUser: InsertUser): Promise<User> {
+  createUser(insertUser: InsertUser): User {
     const id = this.userIdCounter++;
     const now = new Date();
     const user = { ...insertUser, id, created_at: now };
@@ -98,38 +98,38 @@ export class MemStorage implements IStorage {
   }
   
   // Post methods
-  async getPost(id: number): Promise<Post | undefined> {
+  getPost(id: number): Post | undefined {
     return this.posts.get(id);
   }
   
-  async getPostBySlug(slug: string): Promise<Post | undefined> {
+  getPostBySlug(slug: string): Post | undefined {
     return Array.from(this.posts.values()).find(
       (post) => post.slug === slug
     );
   }
   
-  async getPosts(limit = 10, offset = 0): Promise<Post[]> {
+  getPosts(limit = 10, offset = 0): Post[] {
     return Array.from(this.posts.values())
       .filter(post => post.published)
       .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
       .slice(offset, offset + limit);
   }
   
-  async getPostsByCategory(categoryId: number, limit = 10, offset = 0): Promise<Post[]> {
+  getPostsByCategory(categoryId: number, limit = 10, offset = 0): Post[] {
     return Array.from(this.posts.values())
       .filter(post => post.published && post.category_id === categoryId)
       .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
       .slice(offset, offset + limit);
   }
   
-  async getHotPosts(limit = 10): Promise<Post[]> {
+  getHotPosts(limit = 10): Post[] {
     return Array.from(this.posts.values())
       .filter(post => post.published)
       .sort((a, b) => b.heat_count - a.heat_count)
       .slice(0, limit);
   }
   
-  async createPost(insertPost: InsertPost): Promise<Post> {
+  createPost(insertPost: InsertPost): Post {
     const id = this.postIdCounter++;
     const now = new Date();
     const post = { ...insertPost, id, created_at: now, heat_count: 0 };
@@ -137,8 +137,8 @@ export class MemStorage implements IStorage {
     return post;
   }
   
-  async updatePost(id: number, postUpdate: Partial<InsertPost>): Promise<Post> {
-    const post = await this.getPost(id);
+  updatePost(id: number, postUpdate: Partial<InsertPost>): Post {
+    const post = this.getPost(id);
     if (!post) {
       throw new Error(`Post with ID ${id} not found`);
     }
@@ -148,12 +148,12 @@ export class MemStorage implements IStorage {
     return updatedPost;
   }
   
-  async deletePost(id: number): Promise<boolean> {
+  deletePost(id: number): boolean {
     return this.posts.delete(id);
   }
   
-  async incrementHeatCount(id: number): Promise<boolean> {
-    const post = await this.getPost(id);
+  incrementHeatCount(id: number): boolean {
+    const post = this.getPost(id);
     if (!post) {
       return false;
     }
@@ -164,17 +164,17 @@ export class MemStorage implements IStorage {
   }
   
   // Comment methods
-  async getComment(id: number): Promise<Comment | undefined> {
+  getComment(id: number): Comment | undefined {
     return this.comments.get(id);
   }
   
-  async getCommentsByPost(postId: number): Promise<Comment[]> {
+  getCommentsByPost(postId: number): Comment[] {
     return Array.from(this.comments.values())
       .filter(comment => comment.post_id === postId)
       .sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
   }
   
-  async createComment(insertComment: InsertComment): Promise<Comment> {
+  createComment(insertComment: InsertComment): Comment {
     const id = this.commentIdCounter++;
     const now = new Date();
     const comment = { ...insertComment, id, created_at: now };
@@ -182,22 +182,22 @@ export class MemStorage implements IStorage {
     return comment;
   }
   
-  async deleteComment(id: number): Promise<boolean> {
+  deleteComment(id: number): boolean {
     return this.comments.delete(id);
   }
   
   // Gallery methods
-  async getGalleryItem(id: number): Promise<GalleryItem | undefined> {
+  getGalleryItem(id: number): GalleryItem | undefined {
     return this.galleryItems.get(id);
   }
   
-  async getGalleryItems(limit = 10, offset = 0): Promise<GalleryItem[]> {
+  getGalleryItems(limit = 10, offset = 0): GalleryItem[] {
     return Array.from(this.galleryItems.values())
       .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
       .slice(offset, offset + limit);
   }
   
-  async createGalleryItem(insertItem: InsertGalleryItem): Promise<GalleryItem> {
+  createGalleryItem(insertItem: InsertGalleryItem): GalleryItem {
     const id = this.galleryIdCounter++;
     const now = new Date();
     const item = { ...insertItem, id, created_at: now };
@@ -206,21 +206,21 @@ export class MemStorage implements IStorage {
   }
   
   // Category methods
-  async getCategory(id: number): Promise<Category | undefined> {
+  getCategory(id: number): Category | undefined {
     return this.categories.get(id);
   }
   
-  async getCategoryBySlug(slug: string): Promise<Category | undefined> {
+  getCategoryBySlug(slug: string): Category | undefined {
     return Array.from(this.categories.values()).find(
       (category) => category.slug === slug
     );
   }
   
-  async getCategories(): Promise<Category[]> {
+  getCategories(): Category[] {
     return Array.from(this.categories.values());
   }
   
-  async createCategory(insertCategory: InsertCategory): Promise<Category> {
+  createCategory(insertCategory: InsertCategory): Category {
     const id = this.categoryIdCounter++;
     const category = { ...insertCategory, id };
     this.categories.set(id, category);
@@ -238,8 +238,8 @@ export class MemStorage implements IStorage {
       { name: "Anti-Guru", slug: "anti-guru" }
     ];
     
-    defaultCategories.forEach(async (cat) => {
-      await this.createCategory(cat);
+    defaultCategories.forEach((cat) => {
+      this.createCategory(cat);
     });
   }
 }


### PR DESCRIPTION
## Summary
- remove async keywords from MemStorage methods
- update IStorage interface to use sync return types

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6849d5336a148331a9096f6f43eee201