### PR TITLE
Fix error handler to log instead of throwing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -44,7 +44,7 @@ app.use((req, res, next) => {
     const message = err.message || "Internal Server Error";
 
     res.status(status).json({ message });
-    throw err;
+    console.error(err);
   });
 
   // importantly only setup vite in development and after


### PR DESCRIPTION
## Summary
- switch `throw err` in the Express error handler to `console.error`
- leave process running after responding to errors

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6849d52d4d40833197284ab7bb70efe8