### PR TITLE
Add Vitest testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# code-the-fuck-up
+
+## Running Tests
+
+Install dependencies and run the test suite with:
+
+```bash
+npm install
+npm run test
+```
+
+Vitest will execute all `*.test.ts` files under `client/src`.

--- a/client/src/hooks/use-toast.test.ts
+++ b/client/src/hooks/use-toast.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react'
+import { useToast, toast } from './use-toast'
+
+describe('useToast', () => {
+  it('adds listener once and cleans up on unmount', () => {
+    let renders = 0
+    const { unmount } = renderHook(() => {
+      renders++
+      return useToast()
+    })
+
+    act(() => {
+      toast({ title: 'first' })
+    })
+    expect(renders).toBe(2)
+
+    act(() => {
+      toast({ title: 'second' })
+    })
+    expect(renders).toBe(3)
+
+    unmount()
+
+    act(() => {
+      toast({ title: 'third' })
+    })
+    expect(renders).toBe(3)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -95,7 +96,12 @@
     "tailwindcss": "^3.4.14",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/jest-dom": "^6.1.3",
+    "jsdom": "^24.0.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
-  "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
-  "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
+  "include": [
+    "client/src/**/*",
+    "client/src/**/*.test.ts",
+    "shared/**/*",
+    "server/**/*"
+  ],
+  "exclude": ["node_modules", "build", "dist"],
   "compilerOptions": {
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",


### PR DESCRIPTION
## Summary
- install Vitest and testing libraries
- enable tests in TypeScript config
- add test for `useToast`
- document test command

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d4f648c88331bb8cf73ac0d825af