### PR TITLE
Fix terminal key comment

### DIFF
--- a/client/src/hooks/use-terminal.ts
+++ b/client/src/hooks/use-terminal.ts
@@ -114,7 +114,7 @@ export function useTerminal() {
   
   useEffect(() => {
     const handleKeydown = (e: KeyboardEvent) => {
-      // Alt + T to toggle terminal
+      // Alt + t to toggle terminal
       if (e.altKey && e.key === 't') {
         toggleTerminal();
       }


### PR DESCRIPTION
## Summary
- tweak comment about terminal key to show `Alt + t`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6849d4f55ad48331b05744f2daae7643