### PR TITLE
Fix toast hook effect dependency

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -179,7 +179,8 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // The listener should only be registered once on mount.
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure the `useToast` hook only registers its listener once

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node', 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6849d4f423888331ac6ee8df19053cc4