### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist/public
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v2
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -35,3 +35,20 @@ npm start
 
 Ensure that `DATABASE_URL` is defined in your environment before running migrations or the server.
 
+## Deploying to GitHub Pages
+
+To host the static frontend on GitHub Pages:
+
+1. Edit `vite.config.ts` and set the `base` option to the repository name:
+
+   ```ts
+   export default defineConfig({
+     base: "/code-the-fuck-up/",
+     // ...
+   })
+   ```
+
+2. Commit your changes and push to the `main` branch.
+3. GitHub Actions will build the project and deploy the files from `dist/public` to the `gh-pages` environment.
+4. Enable GitHub Pages in your repository settings and choose **GitHub Actions** as the source.
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 export default defineConfig({
+  base: "/code-the-fuck-up/",
   plugins: [
     react(),
     runtimeErrorOverlay(),


### PR DESCRIPTION
## Summary
- set Vite base path for GitHub Pages
- add a GitHub Actions workflow to build and deploy
- document how to deploy the static client

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d7a5039083319d842e0f25f6c551