### PR TITLE
Fix npm scripts for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ npm install
 npm run dev
 ```
 
+On Windows, make sure your environment variables work by using `cross-env` (already
+included in the project). Running the above commands from PowerShell or CMD will
+work out of the box.
+
 The server listens on port **5000** by default.
 
 ## Building and Starting
@@ -32,6 +36,9 @@ Start the production server:
 ```bash
 npm start
 ```
+
+Both development and production scripts set the `NODE_ENV` variable using
+`cross-env` so they run correctly on Windows, macOS and Linux.
 
 Ensure that `DATABASE_URL` is defined in your environment before running migrations or the server.
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev": "cross-env NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "start": "NODE_ENV=production node dist/index.js",
+    "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "test": "vitest"
@@ -101,7 +101,8 @@
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.4.3",
     "@testing-library/jest-dom": "^6.1.3",
-    "jsdom": "^24.0.0"
+    "jsdom": "^24.0.0",
+    "cross-env": "^7.0.3"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"


### PR DESCRIPTION
## Summary
- use cross-env in the npm scripts so `NODE_ENV` works on Windows
- document the cross-env requirement in the README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6882701fef608331bb631fc41a24d725