### PR TITLE
Fix server listen error on Windows

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -60,11 +60,18 @@ app.use((req, res, next) => {
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
   const port = 5000;
-  server.listen({
+
+  const listenOpts: Record<string, any> = {
     port,
     host: "0.0.0.0",
-    reusePort: true,
-  }, () => {
+  };
+
+  // reusePort is not supported on Windows
+  if (process.platform !== "win32") {
+    listenOpts.reusePort = true;
+  }
+
+  server.listen(listenOpts, () => {
     log(`serving on port ${port}`);
   });
 })();


### PR DESCRIPTION
## Summary
- avoid using `reusePort` on Windows OS

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm install` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_e_688271a0c8208331a21268c88d6f1625