### PR TITLE
Fix homepage navigation links and fuck-it mode

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,12 +4,24 @@ import { queryClient } from "./lib/queryClient";
 import { Toaster } from "@/components/ui/toaster";
 import NotFound from "@/pages/NotFound";
 import Home from "@/pages/Home";
+import Rants from "@/pages/Rants";
+import TechLiesPage from "@/pages/TechLiesPage";
+import CringeGalleryPage from "@/pages/CringeGalleryPage";
+import RealDevsPage from "@/pages/RealDevsPage";
+import SubmitCringe from "@/pages/SubmitCringe";
+import SubmitStory from "@/pages/SubmitStory";
 import { useEffect, useState } from "react";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={Home} />
+      <Route path="/rants" component={Rants} />
+      <Route path="/tech-lies" component={TechLiesPage} />
+      <Route path="/cringe" component={CringeGalleryPage} />
+      <Route path="/real-devs" component={RealDevsPage} />
+      <Route path="/submit-cringe" component={SubmitCringe} />
+      <Route path="/submit-story" component={SubmitStory} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,11 @@ import CringeGalleryPage from "@/pages/CringeGalleryPage";
 import RealDevsPage from "@/pages/RealDevsPage";
 import SubmitCringe from "@/pages/SubmitCringe";
 import SubmitStory from "@/pages/SubmitStory";
+import RageModePage from "@/pages/RageModePage";
+import ResumeBuilderPage from "@/pages/ResumeBuilderPage";
+import LinkedInFilterPage from "@/pages/LinkedInFilterPage";
+import FuckupGeneratorPage from "@/pages/FuckupGeneratorPage";
+import ConfessionBoothPage from "@/pages/ConfessionBoothPage";
 import { useEffect, useState } from "react";
 
 function Router() {
@@ -22,6 +27,11 @@ function Router() {
       <Route path="/real-devs" component={RealDevsPage} />
       <Route path="/submit-cringe" component={SubmitCringe} />
       <Route path="/submit-story" component={SubmitStory} />
+      <Route path="/rage-mode" component={RageModePage} />
+      <Route path="/resume-builder" component={ResumeBuilderPage} />
+      <Route path="/linkedin-filter" component={LinkedInFilterPage} />
+      <Route path="/fuckups" component={FuckupGeneratorPage} />
+      <Route path="/confess" component={ConfessionBoothPage} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/layout/Footer.tsx
+++ b/client/src/components/layout/Footer.tsx
@@ -34,12 +34,12 @@ export default function Footer() {
           <div className="w-full md:w-1/4 mb-8 md:mb-0">
             <h3 className="text-white font-bold font-mono mb-4 uppercase">CONTENT</h3>
             <ul className="text-gray-400 font-code space-y-2">
-              <li><Link href="/" className="hover:text-white">Hot Rants</Link></li>
-              <li><Link href="/" className="hover:text-white">Tech Lies We Swallowed</Link></li>
-              <li><Link href="/" className="hover:text-white">Cringe Gallery</Link></li>
-              <li><Link href="/" className="hover:text-white">Real Devs, Real Shit</Link></li>
-              <li><Link href="/" className="hover:text-white">Build. Burn. Rebuild.</Link></li>
-              <li><Link href="/" className="hover:text-white">Anti-Guru Guide</Link></li>
+              <li><a href="#hot-rants" className="hover:text-white">Hot Rants</a></li>
+              <li><a href="#tech-lies" className="hover:text-white">Tech Lies We Swallowed</a></li>
+              <li><a href="#cringe-gallery" className="hover:text-white">Cringe Gallery</a></li>
+              <li><a href="#real-devs" className="hover:text-white">Real Devs, Real Shit</a></li>
+              <li><a href="#features" className="hover:text-white">Build. Burn. Rebuild.</a></li>
+              <li><a href="#anti-guru" className="hover:text-white">Anti-Guru Guide</a></li>
             </ul>
           </div>
           

--- a/client/src/components/layout/Footer.tsx
+++ b/client/src/components/layout/Footer.tsx
@@ -16,16 +16,16 @@ export default function Footer() {
             </Link>
             <p className="text-gray-400 font-code mb-4">A no-bullshit platform for developers tired of fake tech influencer culture, over-polished tutorials, and corporate vanilla bullshit.</p>
             <div className="flex space-x-4">
-              <a href="#" className="text-gray-400 hover:text-white">
+              <a href="https://twitter.com" className="text-gray-400 hover:text-white" target="_blank" rel="noopener noreferrer">
                 <i className="ri-twitter-fill text-xl"></i>
               </a>
-              <a href="#" className="text-gray-400 hover:text-white">
+              <a href="https://github.com" className="text-gray-400 hover:text-white" target="_blank" rel="noopener noreferrer">
                 <i className="ri-github-fill text-xl"></i>
               </a>
-              <a href="#" className="text-gray-400 hover:text-white">
+              <a href="https://discord.com" className="text-gray-400 hover:text-white" target="_blank" rel="noopener noreferrer">
                 <i className="ri-discord-fill text-xl"></i>
               </a>
-              <a href="#" className="text-gray-400 hover:text-white">
+              <a href="https://reddit.com" className="text-gray-400 hover:text-white" target="_blank" rel="noopener noreferrer">
                 <i className="ri-reddit-fill text-xl"></i>
               </a>
             </div>

--- a/client/src/components/layout/Navbar.tsx
+++ b/client/src/components/layout/Navbar.tsx
@@ -25,36 +25,21 @@ export default function Navbar({ fuckItMode, toggleFuckItMode }: NavbarProps) {
         </div>
         
         <div className={`${mobileMenuOpen ? 'flex' : 'hidden'} md:flex items-center space-x-6 text-sm font-code flex-col md:flex-row absolute md:static top-16 left-0 right-0 bg-[#121212] md:bg-transparent p-4 md:p-0 border-b md:border-0 border-[#2a2a2a] gap-4 md:gap-0`}>
-          <Link
-            href="/"
-            className="nav-link active text-white hover:text-secondary uppercase"
-          >
+          <a href="#hot-rants" className="nav-link active text-white hover:text-secondary uppercase">
             HOT RANTS
-          </Link>
-          <Link
-            href="/"
-            className="nav-link text-white hover:text-secondary uppercase"
-          >
+          </a>
+          <a href="#tech-lies" className="nav-link text-white hover:text-secondary uppercase">
             TECH LIES
-          </Link>
-          <Link
-            href="/"
-            className="nav-link text-white hover:text-secondary uppercase"
-          >
+          </a>
+          <a href="#cringe-gallery" className="nav-link text-white hover:text-secondary uppercase">
             CRINGE GALLERY
-          </Link>
-          <Link
-            href="/"
-            className="nav-link text-white hover:text-secondary uppercase"
-          >
+          </a>
+          <a href="#real-devs" className="nav-link text-white hover:text-secondary uppercase">
             REAL DEVS
-          </Link>
-          <Link
-            href="/"
-            className="nav-link text-white hover:text-secondary uppercase"
-          >
+          </a>
+          <a href="#features" className="nav-link text-white hover:text-secondary uppercase">
             BUILD.BURN
-          </Link>
+          </a>
         </div>
         
         <div className="flex items-center">

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -46,6 +46,10 @@
   body {
     @apply font-code antialiased bg-background text-foreground overflow-x-hidden;
   }
+
+  body.fuck-it-mode {
+    filter: invert(1) hue-rotate(180deg);
+  }
 }
 
 @layer utilities {

--- a/client/src/pages/ConfessionBoothPage.tsx
+++ b/client/src/pages/ConfessionBoothPage.tsx
@@ -1,0 +1,2 @@
+import SubmitStory from "./SubmitStory";
+export default SubmitStory;

--- a/client/src/pages/CringeGalleryPage.tsx
+++ b/client/src/pages/CringeGalleryPage.tsx
@@ -1,0 +1,40 @@
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+import ImageGlitch from "@/components/ui/ImageGlitch";
+import TerminalBox from "@/components/ui/TerminalBox";
+import { cringeGallery } from "@/lib/data";
+import { useEffect, useState } from "react";
+
+export default function CringeGalleryPage() {
+  const [fuckItMode, setFuckItMode] = useState(false);
+  useEffect(() => {
+    document.body.classList.toggle("fuck-it-mode", fuckItMode);
+  }, [fuckItMode]);
+
+  return (
+    <>
+      <Navbar fuckItMode={fuckItMode} toggleFuckItMode={() => setFuckItMode(!fuckItMode)} />
+      <main className="py-16 bg-[#121212] min-h-screen">
+        <div className="container mx-auto px-4">
+          <div className="mb-8">
+            <TerminalBox text={'find /linkedin -name "*.cringe" | sort -r'} className="inline-block mb-4" />
+            <h1 className="text-4xl font-bold font-mono text-white uppercase">CRINGE GALLERY</h1>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {cringeGallery.map((item, index) => (
+              <div key={index} className="bg-[#1a1a1a] rounded-lg overflow-hidden shadow-lg">
+                <ImageGlitch src={item.image} alt={item.title} imageClassName="w-full h-48 object-cover" />
+                <div className="p-4">
+                  <h4 className="font-mono text-white font-bold mb-2">{item.title}</h4>
+                  <p className="text-gray-400 text-sm font-code mb-3">{item.description}</p>
+                  <span className="text-xs text-gray-500 font-code">Submitted by <span className="text-secondary">@{item.submittedBy}</span></span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/FuckupGeneratorPage.tsx
+++ b/client/src/pages/FuckupGeneratorPage.tsx
@@ -1,0 +1,35 @@
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+import GlitchButton from "@/components/ui/GlitchButton";
+import { useState, useEffect } from "react";
+import { devStories } from "@/lib/data";
+
+export default function FuckupGeneratorPage() {
+  const [fuckItMode, setFuckItMode] = useState(false);
+  const [story, setStory] = useState(devStories[0].content);
+
+  useEffect(() => {
+    document.body.classList.toggle("fuck-it-mode", fuckItMode);
+  }, [fuckItMode]);
+
+  const generate = () => {
+    const random = devStories[Math.floor(Math.random() * devStories.length)];
+    setStory(random.content);
+  };
+
+  return (
+    <>
+      <Navbar fuckItMode={fuckItMode} toggleFuckItMode={() => setFuckItMode(!fuckItMode)} />
+      <main className="py-16 bg-[#121212] min-h-screen">
+        <div className="container mx-auto px-4 max-w-2xl">
+          <h1 className="text-4xl font-bold font-mono text-white mb-6 uppercase">DAILY FUCK-UP GENERATOR</h1>
+          <GlitchButton onClick={generate} className="bg-primary text-black font-bold py-2 px-4 mb-6" text="GENERATE">
+            GENERATE CATASTROPHE
+          </GlitchButton>
+          <div className="prose prose-invert max-w-none font-code" dangerouslySetInnerHTML={{ __html: story }} />
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -8,10 +8,13 @@ import Features from "@/sections/Features";
 import AntiGuru from "@/sections/AntiGuru";
 import Newsletter from "@/sections/Newsletter";
 import Footer from "@/components/layout/Footer";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export default function Home() {
   const [fuckItMode, setFuckItMode] = useState(false);
+  useEffect(() => {
+    document.body.classList.toggle("fuck-it-mode", fuckItMode);
+  }, [fuckItMode]);
 
   return (
     <>

--- a/client/src/pages/LinkedInFilterPage.tsx
+++ b/client/src/pages/LinkedInFilterPage.tsx
@@ -1,0 +1,48 @@
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+import GlitchButton from "@/components/ui/GlitchButton";
+import { useState, useEffect } from "react";
+
+export default function LinkedInFilterPage() {
+  const [fuckItMode, setFuckItMode] = useState(false);
+  const [post, setPost] = useState("");
+  const [filtered, setFiltered] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.body.classList.toggle("fuck-it-mode", fuckItMode);
+  }, [fuckItMode]);
+
+  const handleFilter = () => {
+    setFiltered(post.replace(/synergy|disrupt|innovative/gi, "bullshit"));
+  };
+
+  return (
+    <>
+      <Navbar fuckItMode={fuckItMode} toggleFuckItMode={() => setFuckItMode(!fuckItMode)} />
+      <main className="py-16 bg-[#181818] min-h-screen">
+        <div className="container mx-auto px-4 max-w-2xl">
+          <h1 className="text-4xl font-bold font-mono text-white mb-6 uppercase">LINKEDIN FILTER</h1>
+          <textarea
+            value={post}
+            onChange={(e) => setPost(e.target.value)}
+            placeholder="Paste cringe LinkedIn post here"
+            className="w-full py-2 px-3 bg-[#242424] border border-[#2a2a2a] rounded text-white font-code h-32 mb-4"
+          />
+          <GlitchButton
+            onClick={handleFilter}
+            className="bg-primary text-black font-bold py-2 px-4 mb-6"
+            text="FILTER IT"
+          >
+            FILTER IT
+          </GlitchButton>
+          {filtered && (
+            <div className="bg-[#1a1a1a] p-4 rounded-lg shadow-lg">
+              <p className="text-gray-300 font-code whitespace-pre-wrap">{filtered}</p>
+            </div>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/RageModePage.tsx
+++ b/client/src/pages/RageModePage.tsx
@@ -1,0 +1,48 @@
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+import GlitchButton from "@/components/ui/GlitchButton";
+import { useState, useEffect } from "react";
+
+export default function RageModePage() {
+  const [fuckItMode, setFuckItMode] = useState(false);
+  const [rage, setRage] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.toggle("fuck-it-mode", fuckItMode);
+  }, [fuckItMode]);
+
+  return (
+    <>
+      <Navbar fuckItMode={fuckItMode} toggleFuckItMode={() => setFuckItMode(!fuckItMode)} />
+      <main className="py-16 bg-[#121212] min-h-screen">
+        <div className="container mx-auto px-4 max-w-2xl">
+          <h1 className="text-4xl font-bold font-mono text-white mb-6 uppercase">RAGE COMMENT MODE</h1>
+          <p className="text-gray-400 font-code mb-4">
+            Toggle between a profanity-laced comment and a safe for work reaction.
+          </p>
+          <div className="mb-6">
+            <GlitchButton
+              onClick={() => setRage(!rage)}
+              className="bg-primary text-black font-bold py-2 px-4"
+              text="TOGGLE RAGE MODE"
+            >
+              TOGGLE RAGE MODE
+            </GlitchButton>
+          </div>
+          <div className="bg-[#1a1a1a] p-6 rounded-lg shadow-lg">
+            {rage ? (
+              <p className="text-red-400 font-code">
+                This article is complete bullshit. Whoever wrote it clearly hasn\'t touched real code in years.
+              </p>
+            ) : (
+              <p className="text-gray-300 font-code">
+                Interesting take! I\'ll have to give these tips a try when I\'m back at my desk.
+              </p>
+            )}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/Rants.tsx
+++ b/client/src/pages/Rants.tsx
@@ -1,0 +1,37 @@
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+import BlogCard from "@/components/ui/BlogCard";
+import { hotRants } from "@/lib/data";
+import { useEffect, useState } from "react";
+
+export default function Rants() {
+  const [fuckItMode, setFuckItMode] = useState(false);
+  useEffect(() => {
+    document.body.classList.toggle("fuck-it-mode", fuckItMode);
+  }, [fuckItMode]);
+
+  return (
+    <>
+      <Navbar fuckItMode={fuckItMode} toggleFuckItMode={() => setFuckItMode(!fuckItMode)} />
+      <main className="py-16 bg-[#121212] min-h-screen">
+        <div className="container mx-auto px-4">
+          <h1 className="text-4xl font-bold font-mono text-white mb-8 uppercase">ALL RANTS</h1>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {hotRants.map((rant, index) => (
+              <BlogCard
+                key={index}
+                title={rant.title}
+                excerpt={rant.excerpt}
+                timeAgo={rant.timeAgo}
+                heatCount={rant.heatCount}
+                author={rant.author}
+                category="RANT"
+              />
+            ))}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/RealDevsPage.tsx
+++ b/client/src/pages/RealDevsPage.tsx
@@ -1,0 +1,68 @@
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+import TerminalBox from "@/components/ui/TerminalBox";
+import { devStories } from "@/lib/data";
+import GlitchButton from "@/components/ui/GlitchButton";
+import { useEffect, useState } from "react";
+import { useLocation } from "wouter";
+
+export default function RealDevsPage() {
+  const [fuckItMode, setFuckItMode] = useState(false);
+  const [, navigate] = useLocation();
+  useEffect(() => {
+    document.body.classList.toggle("fuck-it-mode", fuckItMode);
+  }, [fuckItMode]);
+
+  return (
+    <>
+      <Navbar fuckItMode={fuckItMode} toggleFuckItMode={() => setFuckItMode(!fuckItMode)} />
+      <main className="py-16 bg-[#181818] min-h-screen">
+        <div className="container mx-auto px-4">
+          <div className="flex flex-col md:flex-row mb-12">
+            <div className="w-full md:w-1/2">
+              <TerminalBox text={'cat /dev/reality | grep "truth"'} className="inline-block mb-4" />
+              <h1 className="text-4xl font-bold font-mono text-white mb-4 uppercase">REAL DEVS, REAL SHIT</h1>
+              <p className="text-gray-400 font-code">User-submitted stories of failure, burnout, breakthroughs, and the weird reality of being a developer.</p>
+            </div>
+            <div className="w-full md:w-1/2 md:text-right mt-6 md:mt-0">
+              <GlitchButton
+                className="bg-primary text-black font-bold py-2 px-4"
+                text="SUBMIT YOUR STORY"
+                onClick={() => navigate('/submit-story')}
+              >
+                SUBMIT YOUR STORY <i className="ri-arrow-right-line ml-1"></i>
+              </GlitchButton>
+            </div>
+          </div>
+
+          <div className="bg-[#1a1a1a] rounded-lg shadow-lg p-6 mb-8">
+            <div className="mb-4 flex items-center">
+              <img src={devStories[0].author.image} alt="Developer" className="w-12 h-12 rounded-full mr-4" />
+              <div>
+                <h4 className="font-mono text-white font-bold">{devStories[0].title}</h4>
+                <span className="text-xs text-gray-400 font-code">by <span className="text-secondary">@{devStories[0].author.username}</span> • {devStories[0].timeAgo}</span>
+              </div>
+            </div>
+            <div className="prose prose-invert max-w-none mb-6 font-code text-gray-300" dangerouslySetInnerHTML={{ __html: devStories[0].content }} />
+            <div className="flex items-center justify-between border-t border-[#2a2a2a] pt-4">
+              <div className="flex items-center">
+                <button className="flex items-center text-gray-400 hover:text-primary mr-4">
+                  <i className="ri-heart-line mr-1"></i>
+                  <span className="text-sm">{devStories[0].likes}</span>
+                </button>
+                <button className="flex items-center text-gray-400 hover:text-primary">
+                  <i className="ri-chat-1-line mr-1"></i>
+                  <span className="text-sm">{devStories[0].comments}</span>
+                </button>
+              </div>
+              <button className="text-secondary hover:text-white font-code text-sm">
+                SHARE THIS REALITY CHECK
+              </button>
+            </div>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/ResumeBuilderPage.tsx
+++ b/client/src/pages/ResumeBuilderPage.tsx
@@ -1,0 +1,53 @@
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+import GlitchButton from "@/components/ui/GlitchButton";
+import { useState, useEffect } from "react";
+
+export default function ResumeBuilderPage() {
+  const [fuckItMode, setFuckItMode] = useState(false);
+  const [name, setName] = useState("");
+  const [skills, setSkills] = useState("");
+
+  useEffect(() => {
+    document.body.classList.toggle("fuck-it-mode", fuckItMode);
+  }, [fuckItMode]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    alert(`Congrats ${name}! Your totally truthful resume is ready (not really).`);
+    setName("");
+    setSkills("");
+  };
+
+  return (
+    <>
+      <Navbar fuckItMode={fuckItMode} toggleFuckItMode={() => setFuckItMode(!fuckItMode)} />
+      <main className="py-16 bg-[#121212] min-h-screen">
+        <div className="container mx-auto px-4 max-w-xl">
+          <h1 className="text-4xl font-bold font-mono text-white mb-6 uppercase">REAL RESUME BUILDER</h1>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input
+              type="text"
+              placeholder="Your Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full py-2 px-3 bg-[#242424] border border-[#2a2a2a] rounded text-white font-code"
+              required
+            />
+            <textarea
+              placeholder="Your Skills"
+              value={skills}
+              onChange={(e) => setSkills(e.target.value)}
+              className="w-full py-2 px-3 bg-[#242424] border border-[#2a2a2a] rounded text-white font-code h-32"
+              required
+            />
+            <GlitchButton type="submit" className="bg-primary text-black font-bold py-2 px-4" text="BUILD IT">
+              BUILD IT
+            </GlitchButton>
+          </form>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/SubmitCringe.tsx
+++ b/client/src/pages/SubmitCringe.tsx
@@ -1,0 +1,63 @@
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+import GlitchButton from "@/components/ui/GlitchButton";
+import { useEffect, useState } from "react";
+
+export default function SubmitCringe() {
+  const [fuckItMode, setFuckItMode] = useState(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [image, setImage] = useState("");
+
+  useEffect(() => {
+    document.body.classList.toggle("fuck-it-mode", fuckItMode);
+  }, [fuckItMode]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Placeholder submit handler
+    alert("Thanks for submitting your cringe!");
+    setTitle("");
+    setDescription("");
+    setImage("");
+  };
+
+  return (
+    <>
+      <Navbar fuckItMode={fuckItMode} toggleFuckItMode={() => setFuckItMode(!fuckItMode)} />
+      <main className="py-16 bg-[#121212] min-h-screen">
+        <div className="container mx-auto px-4 max-w-xl">
+          <h1 className="text-3xl font-bold font-mono text-white mb-6 uppercase">SUBMIT YOUR CRINGE</h1>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+              placeholder="Title"
+              className="w-full py-2 px-3 bg-[#242424] border border-[#2a2a2a] rounded text-white font-code"
+            />
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              required
+              placeholder="Description"
+              className="w-full py-2 px-3 bg-[#242424] border border-[#2a2a2a] rounded text-white font-code h-32"
+            />
+            <input
+              type="url"
+              value={image}
+              onChange={(e) => setImage(e.target.value)}
+              placeholder="Image URL"
+              className="w-full py-2 px-3 bg-[#242424] border border-[#2a2a2a] rounded text-white font-code"
+            />
+            <GlitchButton type="submit" text="SUBMIT" className="bg-primary text-black font-bold py-2 px-4">
+              SUBMIT
+            </GlitchButton>
+          </form>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/SubmitStory.tsx
+++ b/client/src/pages/SubmitStory.tsx
@@ -1,0 +1,53 @@
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+import GlitchButton from "@/components/ui/GlitchButton";
+import { useEffect, useState } from "react";
+
+export default function SubmitStory() {
+  const [fuckItMode, setFuckItMode] = useState(false);
+  const [title, setTitle] = useState("");
+  const [story, setStory] = useState("");
+
+  useEffect(() => {
+    document.body.classList.toggle("fuck-it-mode", fuckItMode);
+  }, [fuckItMode]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    alert("Story submitted! Thanks for keeping it real.");
+    setTitle("");
+    setStory("");
+  };
+
+  return (
+    <>
+      <Navbar fuckItMode={fuckItMode} toggleFuckItMode={() => setFuckItMode(!fuckItMode)} />
+      <main className="py-16 bg-[#181818] min-h-screen">
+        <div className="container mx-auto px-4 max-w-xl">
+          <h1 className="text-3xl font-bold font-mono text-white mb-6 uppercase">SUBMIT YOUR STORY</h1>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+              placeholder="Title"
+              className="w-full py-2 px-3 bg-[#242424] border border-[#2a2a2a] rounded text-white font-code"
+            />
+            <textarea
+              value={story}
+              onChange={(e) => setStory(e.target.value)}
+              required
+              placeholder="Your story"
+              className="w-full py-2 px-3 bg-[#242424] border border-[#2a2a2a] rounded text-white font-code h-40"
+            />
+            <GlitchButton type="submit" text="SUBMIT" className="bg-primary text-black font-bold py-2 px-4">
+              SUBMIT
+            </GlitchButton>
+          </form>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/TechLiesPage.tsx
+++ b/client/src/pages/TechLiesPage.tsx
@@ -1,0 +1,52 @@
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+import TerminalBox from "@/components/ui/TerminalBox";
+import { techLies } from "@/lib/data";
+import { useEffect, useState } from "react";
+import { Link } from "wouter";
+
+export default function TechLiesPage() {
+  const [fuckItMode, setFuckItMode] = useState(false);
+  useEffect(() => {
+    document.body.classList.toggle("fuck-it-mode", fuckItMode);
+  }, [fuckItMode]);
+
+  return (
+    <>
+      <Navbar fuckItMode={fuckItMode} toggleFuckItMode={() => setFuckItMode(!fuckItMode)} />
+      <main className="py-16 bg-[#181818] min-h-screen">
+        <div className="container mx-auto px-4">
+          <div className="mb-8">
+            <TerminalBox text={'grep -r "bullshit" ./tech_industry'} className="inline-block mb-4" />
+            <h1 className="text-4xl font-bold font-mono text-white uppercase">TECH LIES WE SWALLOWED</h1>
+          </div>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            {techLies.map((lie, index) => (
+              <div key={index} className="bg-[#1a1a1a] p-6 rounded-lg shadow-lg slanted-bg">
+                <div className="flex items-center mb-4">
+                  <div className="w-12 h-12 bg-primary bg-opacity-20 rounded-full flex items-center justify-center mr-4">
+                    <i className="ri-error-warning-fill text-2xl text-primary"></i>
+                  </div>
+                  <h3 className="text-xl font-bold font-mono text-white glitch-hover">{lie.title}</h3>
+                </div>
+                <p className="text-gray-400 font-code mb-6">{lie.content}</p>
+                <div className="flex items-center justify-between">
+                  <Link href="/tech-lies" className="text-secondary font-code hover:text-white transition">
+                    READ FULL TAKEDOWN →
+                  </Link>
+                  <div className="flex items-center">
+                    <button className="mr-3 text-gray-400 hover:text-primary">
+                      <i className="ri-thumb-up-line"></i>
+                    </button>
+                    <span className="text-gray-500 text-sm">{lie.likes}</span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/sections/AntiGuru.tsx
+++ b/client/src/sections/AntiGuru.tsx
@@ -51,7 +51,7 @@ export default function AntiGuru() {
                   <GlitchButton
                     className="bg-primary text-black font-bold py-2 px-6"
                     text={guru.buttonText}
-                    onClick={() => {}}
+                    onClick={() => alert('This does nothing, thankfully.')}
                   >
                     {guru.buttonText}
                   </GlitchButton>

--- a/client/src/sections/AntiGuru.tsx
+++ b/client/src/sections/AntiGuru.tsx
@@ -5,7 +5,7 @@ import { antiGurus } from "@/lib/data";
 
 export default function AntiGuru() {
   return (
-    <section className="py-16 bg-[#181818] relative">
+    <section id="anti-guru" className="py-16 bg-[#181818] relative">
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row mb-12">
           <div className="w-full md:w-1/2">

--- a/client/src/sections/CringeGallery.tsx
+++ b/client/src/sections/CringeGallery.tsx
@@ -8,7 +8,7 @@ interface CringeGalleryProps {
 
 export default function CringeGallery({ fuckItMode }: CringeGalleryProps) {
   return (
-    <section className="py-16 bg-[#121212]">
+    <section id="cringe-gallery" className="py-16 bg-[#121212]">
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row mb-12">
           <div className="w-full md:w-1/2">

--- a/client/src/sections/CringeGallery.tsx
+++ b/client/src/sections/CringeGallery.tsx
@@ -1,6 +1,7 @@
 import TerminalBox from "@/components/ui/TerminalBox";
 import ImageGlitch from "@/components/ui/ImageGlitch";
 import { cringeGallery } from "@/lib/data";
+import { Link } from "wouter";
 
 interface CringeGalleryProps {
   fuckItMode: boolean;
@@ -20,10 +21,10 @@ export default function CringeGallery({ fuckItMode }: CringeGalleryProps) {
             <p className="text-gray-400 font-code">Screenshots of awful LinkedIn flexes, resume disasters, and self-important tech posts that make us all die inside.</p>
           </div>
           <div className="w-full md:w-1/2 md:text-right mt-6 md:mt-0">
-            <a href="#" className="inline-flex items-center text-secondary hover:text-white transition duration-200">
+            <Link href="/submit-cringe" className="inline-flex items-center text-secondary hover:text-white transition duration-200">
               <span className="mr-2 font-code">SUBMIT YOUR CRINGE</span>
               <i className="ri-arrow-right-line"></i>
-            </a>
+            </Link>
           </div>
         </div>
 

--- a/client/src/sections/Features.tsx
+++ b/client/src/sections/Features.tsx
@@ -1,6 +1,7 @@
 import TerminalBox from "@/components/ui/TerminalBox";
 import { features } from "@/lib/data";
 import { useState } from "react";
+import { Link } from "wouter";
 
 export default function Features() {
   const [showDeployModal, setShowDeployModal] = useState(false);
@@ -51,7 +52,22 @@ export default function Features() {
                   {feature.buttonText}
                 </button>
               ) : (
-                <a href="#" className="text-secondary font-code hover:text-white transition text-sm">{feature.buttonText}</a>
+                <Link
+                  href={
+                    feature.id === 'rage-mode'
+                      ? '/rage-mode'
+                      : feature.id === 'resume-builder'
+                      ? '/resume-builder'
+                      : feature.id === 'linkedin-filter'
+                      ? '/linkedin-filter'
+                      : feature.id === 'fuckup-generator'
+                      ? '/fuckups'
+                      : '/confess'
+                  }
+                  className="text-secondary font-code hover:text-white transition text-sm"
+                >
+                  {feature.buttonText}
+                </Link>
               )}
             </div>
           ))}

--- a/client/src/sections/Features.tsx
+++ b/client/src/sections/Features.tsx
@@ -23,7 +23,7 @@ export default function Features() {
   };
 
   return (
-    <section className="py-16 bg-[#121212]">
+    <section id="features" className="py-16 bg-[#121212]">
       <div className="container mx-auto px-4">
         <div className="mb-12 text-center">
           <TerminalBox 

--- a/client/src/sections/Hero.tsx
+++ b/client/src/sections/Hero.tsx
@@ -22,7 +22,7 @@ export default function Hero() {
   };
 
   return (
-    <section className="relative py-20 overflow-hidden bg-[#181818]">
+    <section id="hero" className="relative py-20 overflow-hidden bg-[#181818]">
       <div className="container mx-auto px-4 relative z-10">
         <div className="flex flex-col md:flex-row items-center justify-between">
           <div className="md:w-1/2 mb-10 md:mb-0">

--- a/client/src/sections/Hero.tsx
+++ b/client/src/sections/Hero.tsx
@@ -3,6 +3,7 @@ import GlitchText from "@/components/ui/GlitchText";
 import TypingText from "@/components/ui/TypingText";
 import ImageGlitch from "@/components/ui/ImageGlitch";
 import { useState } from "react";
+import { Link } from "wouter";
 
 export default function Hero() {
   const [showQuoteModal, setShowQuoteModal] = useState(false);
@@ -45,10 +46,13 @@ export default function Hero() {
               >
                 DEPLOY OR DIE <i className="ri-rocket-2-fill ml-1"></i>
               </GlitchButton>
-              <a href="#" className="inline-flex items-center text-secondary hover:text-white transition duration-200 mb-4 md:mb-0">
+              <Link
+                href="/confess"
+                className="inline-flex items-center text-secondary hover:text-white transition duration-200 mb-4 md:mb-0"
+              >
                 <span className="mr-2 font-code">CONFESS YOUR CODE SINS</span>
                 <i className="ri-arrow-right-line"></i>
-              </a>
+              </Link>
             </div>
           </div>
           <div className="md:w-1/2">

--- a/client/src/sections/HotRants.tsx
+++ b/client/src/sections/HotRants.tsx
@@ -1,6 +1,7 @@
 import TerminalBox from "@/components/ui/TerminalBox";
 import BlogCard from "@/components/ui/BlogCard";
 import { useEffect, useState } from "react";
+import { Link } from "wouter";
 import { hotRants } from "@/lib/data";
 
 interface HotRantsProps {
@@ -34,10 +35,10 @@ export default function HotRants({ fuckItMode }: HotRantsProps) {
             <p className="text-gray-400 font-code">Raw blog posts about the real dev life, no filter, no bullshit.</p>
           </div>
           <div className="w-full md:w-1/2 md:text-right mt-6 md:mt-0">
-            <a href="#" className="inline-flex items-center text-secondary hover:text-white transition duration-200">
+            <Link href="/rants" className="inline-flex items-center text-secondary hover:text-white transition duration-200">
               <span className="mr-2 font-code">VIEW ALL RANTS</span>
               <i className="ri-arrow-right-line"></i>
-            </a>
+            </Link>
           </div>
         </div>
 

--- a/client/src/sections/HotRants.tsx
+++ b/client/src/sections/HotRants.tsx
@@ -22,7 +22,7 @@ export default function HotRants({ fuckItMode }: HotRantsProps) {
   }, [fuckItMode]);
 
   return (
-    <section className="py-16 bg-[#121212]">
+    <section id="hot-rants" className="py-16 bg-[#121212]">
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row mb-12">
           <div className="w-full md:w-1/2">

--- a/client/src/sections/Newsletter.tsx
+++ b/client/src/sections/Newsletter.tsx
@@ -15,7 +15,7 @@ export default function Newsletter() {
   };
 
   return (
-    <section className="py-16 bg-[#121212]">
+    <section id="newsletter" className="py-16 bg-[#121212]">
       <div className="container mx-auto px-4">
         <div className="max-w-3xl mx-auto text-center">
           <TerminalBox 

--- a/client/src/sections/RealDevs.tsx
+++ b/client/src/sections/RealDevs.tsx
@@ -8,7 +8,7 @@ interface RealDevsProps {
 
 export default function RealDevs({ fuckItMode }: RealDevsProps) {
   return (
-    <section className="py-16 bg-[#181818]">
+    <section id="real-devs" className="py-16 bg-[#181818]">
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row mb-12">
           <div className="w-full md:w-1/2">

--- a/client/src/sections/RealDevs.tsx
+++ b/client/src/sections/RealDevs.tsx
@@ -1,12 +1,14 @@
 import TerminalBox from "@/components/ui/TerminalBox";
 import GlitchButton from "@/components/ui/GlitchButton";
 import { devStories } from "@/lib/data";
+import { useLocation } from "wouter";
 
 interface RealDevsProps {
   fuckItMode: boolean;
 }
 
 export default function RealDevs({ fuckItMode }: RealDevsProps) {
+  const [, navigate] = useLocation();
   return (
     <section id="real-devs" className="py-16 bg-[#181818]">
       <div className="container mx-auto px-4">
@@ -23,7 +25,7 @@ export default function RealDevs({ fuckItMode }: RealDevsProps) {
             <GlitchButton
               className="bg-primary text-black font-bold py-2 px-4"
               text="SUBMIT YOUR STORY"
-              onClick={() => {}}
+              onClick={() => navigate('/submit-story')}
             >
               SUBMIT YOUR STORY <i className="ri-arrow-right-line ml-1"></i>
             </GlitchButton>

--- a/client/src/sections/TechLies.tsx
+++ b/client/src/sections/TechLies.tsx
@@ -7,7 +7,7 @@ interface TechLiesProps {
 
 export default function TechLies({ fuckItMode }: TechLiesProps) {
   return (
-    <section className="py-16 bg-[#181818] relative">
+    <section id="tech-lies" className="py-16 bg-[#181818] relative">
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row mb-12">
           <div className="w-full md:w-1/2">

--- a/client/src/sections/TechLies.tsx
+++ b/client/src/sections/TechLies.tsx
@@ -1,5 +1,6 @@
 import TerminalBox from "@/components/ui/TerminalBox";
 import { techLies } from "@/lib/data";
+import { Link } from "wouter";
 
 interface TechLiesProps {
   fuckItMode: boolean;
@@ -19,10 +20,10 @@ export default function TechLies({ fuckItMode }: TechLiesProps) {
             <p className="text-gray-400 font-code">Busting myths, influencer lies, and fake job titles one painful truth at a time.</p>
           </div>
           <div className="w-full md:w-1/2 md:text-right mt-6 md:mt-0">
-            <a href="#" className="inline-flex items-center text-secondary hover:text-white transition duration-200">
+            <Link href="/tech-lies" className="inline-flex items-center text-secondary hover:text-white transition duration-200">
               <span className="mr-2 font-code">VIEW ALL TECH LIES</span>
               <i className="ri-arrow-right-line"></i>
-            </a>
+            </Link>
           </div>
         </div>
 
@@ -37,7 +38,7 @@ export default function TechLies({ fuckItMode }: TechLiesProps) {
               </div>
               <p className="text-gray-400 font-code mb-6">{lie.content}</p>
               <div className="flex items-center justify-between">
-                <a href="#" className="text-secondary font-code hover:text-white transition">READ FULL TAKEDOWN →</a>
+                <Link href="/tech-lies" className="text-secondary font-code hover:text-white transition">READ FULL TAKEDOWN →</Link>
                 <div className="flex items-center">
                   <button className="mr-3 text-gray-400 hover:text-primary">
                     <i className="ri-thumb-up-line"></i>


### PR DESCRIPTION
## Summary
- anchor each section for scroll navigation
- update navbar and footer links to use hashes
- toggle a new `fuck-it-mode` class on `<body>` when the button is clicked
- add CSS for `fuck-it-mode`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688274dde45c83319639a49f9d4f3a6e