### PR TITLE
Fix blog markdown rendering

### DIFF
--- a/client/src/lib/data.ts
+++ b/client/src/lib/data.ts
@@ -12,69 +12,63 @@ export const hotRants = [
     },
     category: "INDUSTRY EXPOSE",
     fullContent: `
-# LPA: Lies Per Annum - The ₹80 LPA Scam Exposed
-
-**TL;DR** – If you slap "₹80 LPA" on a YouTube thumbnail without showing the cold, crusty pay-slip, you're not educating aspirants—you're peddling delusions for clicks. Stop it, or keep doing it and enjoy this digital Molotov cocktail in your comments.
-
-## Welcome to the Circus of Comp Packages
-
-Look, I get it. "Lakhs Per Annum" sounds sexier than "CTC if, maybe, the stars align and HR doesn't change policy halfway through Q3." It's the influencer equivalent of those real-estate flyers that start with "ONLY ₹99 LACS"*—the asterisk is silent but deadly.
-
+LPA: Lies Per Annum
+TL;DR – If you slap “₹80 LPA” on a YouTube thumbnail without showing the cold, crusty
+pay-slip, you’re not educating aspirants—you’re peddling delusions for clicks. Stop it, or keep
+doing it and enjoy this digital Molotov cocktail in your comments.
+Welcome to the Circus of Comp Packages
+Look, I get it. “Lakhs Per Annum” sounds sexier than “CTC if, maybe, the stars align and HR
+doesn’t change policy halfway through Q3.” It’s the influencer equivalent of those real-estate
+flyers that start with “ONLY ₹99 LACS”*—the asterisk is silent but deadly.
 The formula seems simple:
-
-**Inflated LPA = (Actual Fixed Pay) + (Variable That Never Vests) + (Signing Bonus You Have to Repay If You Breathe Funny) + (ESOPs You'll Exercise in 2078)**
-
-Round it up, slap it on Canva, pose with crossed arms, sprinkle emojis, and boom—instant dopamine buffet for job-hungry graduates.
-
-## "But Bro, It's Technically Correct!"
-
-Yes, "technically correct" the same way a roadside vendor selling "pure cow ghee" in a reused shampoo bottle is technically correct—the bottle did once see shampoo. You're banking on jargon confusion:
-
-### Buzzword Reality Check
-- **LPA**: Lakhs Promised Annually, a fantasy figure pre-tax, pre-PF, pre-everything.
-- **CTC**: Costs The Company—translation: Budgets you'll never touch (hello, office cab allowance you can't claim WFH).
-- **In-hand**: The money that actually lands before rent, mutual funds, and the chai tapri. Usually 55-65% of the click-bait number.
-
-## Why This Scam Works
-
-- **Vanity metrics rule LinkedIn feeds**: People share offer letters like they're Oscar trophies.
-- **FOMO sells courses**: "This student cracked ₹1 Cr package after my ₹4,999 résumé workshop!" Sure, buddy. Show me her revised payslip after relocation costs.
-- **Algorithm worship**: Anger + aspiration = engagement. And engagement = AdSense rupees. Simple.
-
-## The Human Fallout
-
-- Freshers torching their mental health trying to chase an 80 LPA mirage when the median take-home might be ₹45k/month.
-- Parents re-mortgaging houses to fund coding bootcamps marketed with those inflated numbers.
-- Mid-career devs feeling like failures for a perfectly respectable 25 LPA fixed.
-
-Congrats, "influencers"—your thumbnails are the new unattainable Instagram beach body.
-
-## My Prescription (Spoiler: It Still Lets You Make Money)
-
-- **Show the math**: One screenshot of the salary break-up > 1,000 reaction-baiting arrows on a thumbnail.
-- **Use monthly in-hand as the headline**: That's what pays rent, not phantom ESOPs.
-- **Separate fixed vs. variable**: If the variable is tied to EBITA you don't influence, stop pretending it's guaranteed.
-- **If you must flex—flex transparency**: You'll stand out in a sea of pixel-pumped numbers.
-
-Or keep lying. Just don't whine about hate comments. You earned every syllable.
-
-## Final Roast for the Road
-
-"Yo bro, but it's just marketing!"
-
-If your "marketing" relies on half-truths, congratulations—you're not a creator, you're a diet Ponzi schemer with a ring light. Pack up the ring light, learn basic arithmetic, and maybe—just maybe—try being as passionate about accuracy as you are about affiliate links.
-
-## Call-out to Readers
-
-Seen a wild "₹1 Cr LPA" claim lately? Drop the link below; let's fact-check it with the same gusto we reserve for Big Boss spoilers. Nothing heals collective delusion like public spreadsheets.
-
-## Bottom Line
-
-"Lakhs Per Annum" is a metric, but it sure as hell isn't your metric until the money kisses your bank account. Until then, it's just another number influencers stretch like cheap pizza cheese to keep you drooling.
-
----
-
-*Share this post with every aspiring developer getting fooled by inflated salary promises. It's time to call out the bullshit.*
+Inflated LPA = (Actual Fixed Pay) + (Variable That Never Vests) + (Signing Bonus You Have to
+Repay If You Breathe Funny) + (ESOPs You’ll Exercise in 2078)
+Round it up, slap it on Canva, pose with crossed arms, sprinkle emojis, and boom—instant
+dopamine buffet for job-hungry graduates.
+“But Bro, It’s Technically Correct!”
+Yes, “technically correct” the same way a roadside vendor selling “pure cow ghee” in a reused
+shampoo bottle is technically correct—the bottle did once see shampoo. You’re banking on
+jargon confusion:
+Buzzword Reality Check
+● LPA Lakhs Promised Annually, a fantasy figure pre-tax, pre-PF, pre-everything.
+● CTC Costs The Company—translation: Budgets you’ll never touch (hello, office cab
+allowance you can’t claim WFH).
+● In-hand The money that actually lands before rent, mutual funds, and the chai tapri.
+Usually 55-65 % of the click-bait number.
+Why This Scam Works
+● Vanity metrics rule LinkedIn feeds: People share offer letters like they’re Oscar
+trophies.
+● FOMO sells courses: “This student cracked ₹1 Cr package after my ₹4,999 résumé
+workshop!” Sure, buddy. Show me her revised payslip after relocation costs.
+● Algorithm worship: Anger + aspiration = engagement. And engagement = AdSense
+rupees. Simple.
+The Human Fallout
+● Freshers torching their mental health trying to chase an 80 LPA mirage when the median
+take-home might be ₹45k/month.
+● Parents re-mortgaging houses to fund coding bootcamps marketed with those inflated
+numbers.
+● Mid-career devs feeling like failures for a perfectly respectable 25 LPA fixed.
+Congrats, “influencers”—your thumbnails are the new unattainable Instagram beach body.
+My Prescription (Spoiler: It Still Lets You Make Money)
+● Show the math. One screenshot of the salary break-up > 1,000 reaction-baiting arrows
+on a thumbnail.
+● Use monthly in-hand as the headline. That’s what pays rent, not phantom ESOPs.
+● Separate fixed vs. variable. If the variable is tied to EBITA you don’t influence, stop
+pretending it’s guaranteed.
+● If you must flex—flex transparency. You’ll stand out in a sea of pixel-pumped numbers.
+Or keep lying. Just don’t whine about hate comments. You earned every syllable.
+Final Roast for the Road
+“Yo bro, but it’s just marketing!”
+If your “marketing” relies on half-truths, congratulations—you’re not a creator, you’re a diet
+Ponzi schemer with a ring light. Pack up the ring light, learn basic arithmetic, and maybe—just
+maybe—try being as passionate about accuracy as you are about affiliate links.
+Call-out to Readers
+Seen a wild “₹1 Cr LPA” claim lately? Drop the link below; let’s fact-check it with the same gusto
+we reserve for Big Boss spoilers. Nothing heals collective delusion like public spreadsheets.
+Bottom Line
+“Lakhs Per Annum” is a metric, but it sure as hell isn’t your metric until the money kisses your
+bank account. Until then, it’s just another number influencers stretch like cheap pizza cheese to
+keep you drooling.
 `
   },
   {

--- a/client/src/lib/markdown.ts
+++ b/client/src/lib/markdown.ts
@@ -1,0 +1,69 @@
+export function markdownToHtml(md: string): string {
+  const escape = (s: string) =>
+    s
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+
+  const processInline = (text: string) => {
+    return escape(text)
+      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*([^*]+)\*/g, '<em>$1</em>');
+  };
+
+  const lines = md.split(/\n/);
+  let html = "";
+  let inUl = false;
+  let inOl = false;
+
+  const closeLists = () => {
+    if (inUl) {
+      html += "</ul>";
+      inUl = false;
+    }
+    if (inOl) {
+      html += "</ol>";
+      inOl = false;
+    }
+  };
+
+  for (const line of lines) {
+    if (/^###\s+/.test(line)) {
+      closeLists();
+      html += `<h3>${processInline(line.replace(/^###\s+/, ""))}</h3>`;
+    } else if (/^##\s+/.test(line)) {
+      closeLists();
+      html += `<h2>${processInline(line.replace(/^##\s+/, ""))}</h2>`;
+    } else if (/^#\s+/.test(line)) {
+      closeLists();
+      html += `<h1>${processInline(line.replace(/^#\s+/, ""))}</h1>`;
+    } else if (/^---\s*$/.test(line)) {
+      closeLists();
+      html += "<hr />";
+    } else if (/^\d+\.\s+/.test(line)) {
+      if (!inOl) {
+        closeLists();
+        html += "<ol>";
+        inOl = true;
+      }
+      html += `<li>${processInline(line.replace(/^\d+\.\s+/, ""))}</li>`;
+    } else if (/^[-*]\s+/.test(line)) {
+      if (!inUl) {
+        closeLists();
+        html += "<ul>";
+        inUl = true;
+      }
+      html += `<li>${processInline(line.replace(/^[-*]\s+/, ""))}</li>`;
+    } else if (line.trim() === "") {
+      closeLists();
+    } else {
+      closeLists();
+      html += `<p>${processInline(line)}</p>`;
+    }
+  }
+
+  closeLists();
+  return html;
+}

--- a/client/src/pages/RantDetail.tsx
+++ b/client/src/pages/RantDetail.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from "wouter";
 import { hotRants } from "@/lib/data";
 import TerminalBox from "@/components/ui/TerminalBox";
 import GlitchButton from "@/components/ui/GlitchButton";
+import { markdownToHtml } from "@/lib/markdown";
 
 export default function RantDetail() {
   const { slug } = useParams<{ slug: string }>();
@@ -10,6 +11,7 @@ export default function RantDetail() {
   const [comments, setComments] = useState<any[]>([]);
   const [newComment, setNewComment] = useState("");
   const [liked, setLiked] = useState(false);
+  const [htmlContent, setHtmlContent] = useState("");
 
   useEffect(() => {
     // Find the rant by slug
@@ -18,10 +20,10 @@ export default function RantDetail() {
     );
     
     if (foundRant) {
-      setRant({
-        ...foundRant,
-        fullContent: generateFullContent(foundRant)
-      });
+      setRant(foundRant);
+      const content =
+        foundRant.fullContent || generateFullContent(foundRant);
+      setHtmlContent(markdownToHtml(content));
       
       // Load mock comments
       setComments([
@@ -150,9 +152,10 @@ ${rant.author.name}
           </div>
 
           <div className="prose prose-invert max-w-none">
-            <div className="whitespace-pre-wrap font-code text-gray-300 leading-relaxed">
-              {rant.fullContent}
-            </div>
+            <div
+              className="whitespace-pre-wrap font-code text-gray-300 leading-relaxed"
+              dangerouslySetInnerHTML={{ __html: htmlContent }}
+            />
           </div>
         </article>
 

--- a/client/src/pages/TechLieDetail.tsx
+++ b/client/src/pages/TechLieDetail.tsx
@@ -3,11 +3,13 @@ import { Link, useParams } from "wouter";
 import { techLies } from "@/lib/data";
 import TerminalBox from "@/components/ui/TerminalBox";
 import GlitchButton from "@/components/ui/GlitchButton";
+import { markdownToHtml } from "@/lib/markdown";
 
 export default function TechLieDetail() {
   const { slug } = useParams<{ slug: string }>();
   const [lie, setLie] = useState<any>(null);
   const [voted, setVoted] = useState(false);
+  const [htmlContent, setHtmlContent] = useState("");
 
   useEffect(() => {
     // Find the lie by slug
@@ -16,10 +18,10 @@ export default function TechLieDetail() {
     );
     
     if (foundLie) {
-      setLie({
-        ...foundLie,
-        fullTakedown: generateFullTakedown(foundLie)
-      });
+      setLie(foundLie);
+      const content =
+        (foundLie as any).fullTakedown || generateFullTakedown(foundLie);
+      setHtmlContent(markdownToHtml(content));
     }
   }, [slug]);
 
@@ -151,9 +153,10 @@ Stop chasing every shiny new thing. Master the fundamentals. Build stuff that wo
           </div>
 
           <div className="prose prose-invert max-w-none">
-            <div className="whitespace-pre-wrap font-code text-gray-300 leading-relaxed">
-              {lie.fullTakedown}
-            </div>
+            <div
+              className="whitespace-pre-wrap font-code text-gray-300 leading-relaxed"
+              dangerouslySetInnerHTML={{ __html: htmlContent }}
+            />
           </div>
         </article>
 


### PR DESCRIPTION
## Summary
- parse markdown to HTML with new `markdownToHtml` helper
- use parsed HTML in RantDetail and TechLieDetail
- keep original LPA rant text in data

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882815478208331aecf609112ef1bc8