### PR TITLE
Enable GitHub Pages static build

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,7 +31,7 @@ jobs:
       run: npm ci
       
     - name: Build for static deployment
-      run: npx vite build --outDir dist
+      run: npm run build:static
       
     - name: Setup Pages
       uses: actions/configure-pages@v4

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ npm run build:static
    - Choose the branch containing your `dist` folder
    - Set folder to `/dist` or `/docs` depending on your setup
 
-4. **Add GitHub Actions workflow** (`.github/workflows/deploy.yml`):
+4. **GitHub Actions workflow** (`.github/workflows/static.yml`) is already included:
 ```yaml
 name: Deploy to GitHub Pages
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
-    "test": "vitest"
+    "test": "vitest",
+    "build:static": "vite build --outDir dist",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
## Summary
- add static build script and preview command
- tweak README to mention included GitHub Actions workflow
- update CI workflow to use the new build script

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688284b2c420833197d25f4ba64b1069