### PR TITLE
Add placeholder docs for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ npm run build:static
    - Select "Deploy from a branch"
    - Choose the branch containing your `dist` folder
    - Set folder to `/dist` or `/docs` depending on your setup
+   - If you cannot run the build locally, you can commit a basic `docs/index.html`
+     placeholder so GitHub Pages has an `index.html` to serve while the workflow
+     builds the real site.
 
 4. **GitHub Actions workflow** (`.github/workflows/static.yml`) is already included:
 ```yaml

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CODE THE FUCK UP</title>
+  </head>
+  <body>
+    <h1>CODE THE FUCK UP</h1>
+    <p>The static build has not been generated in this environment.</p>
+    <p>Run <code>npm run build:static</code> locally or allow GitHub Actions to build and deploy.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal `docs/index.html` so GitHub Pages always has an index
- document the placeholder option in the GitHub Pages setup section of the README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882862a8ad483319e1c9e94818c7d05